### PR TITLE
Add project filter panel accessible via 'f' keybinding

### DIFF
--- a/src/tasks_tui/app.py
+++ b/src/tasks_tui/app.py
@@ -1362,8 +1362,8 @@ class ProjectFilterScreen(ModalScreen):
 
     BINDINGS = [
         Binding("escape", "close_filter", "Close"),
-        Binding("a", "select_all", "All"),
-        Binding("n", "deselect_all", "None"),
+        Binding("ctrl+a", "select_all", "All", priority=True),
+        Binding("ctrl+n", "deselect_all", "None", priority=True),
     ]
 
     def __init__(self, config: dict) -> None:
@@ -1375,9 +1375,10 @@ class ProjectFilterScreen(ModalScreen):
             yield Label("PROJECTS", id="filter-title")
             yield Input(placeholder="Search…", id="filter-search")
             yield Vertical(id="filter-rows")
-            yield Static("a all · n none · esc close", id="filter-hint")
+            yield Static("ctrl+a all · ctrl+n none · esc close", id="filter-hint")
 
     def on_mount(self) -> None:
+        self.query_one("#filter-search", Input).focus()
         self._discover()
 
     @work(thread=True)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -860,7 +860,7 @@ async def test_filter_screen_reflects_visible_state():
 
 @pytest.mark.asyncio
 async def test_filter_screen_select_all():
-    """'a' action sets all visible toggles to True."""
+    """ctrl+a action sets all visible toggles to True."""
     from tasks_tui.app import ProjectFilterRow
     with (
         patch("tasks_tui.app.list_tasks", return_value=[]),
@@ -878,7 +878,7 @@ async def test_filter_screen_select_all():
 
 @pytest.mark.asyncio
 async def test_filter_screen_deselect_all():
-    """'n' action sets all visible toggles to False."""
+    """ctrl+n action sets all visible toggles to False."""
     from tasks_tui.app import ProjectFilterRow
     with (
         patch("tasks_tui.app.list_tasks", return_value=[]),
@@ -892,6 +892,56 @@ async def test_filter_screen_deselect_all():
             screen.action_deselect_all()
             await pilot.pause()
             assert not any(r.is_visible for r in screen.query(ProjectFilterRow))
+
+
+@pytest.mark.asyncio
+async def test_filter_screen_search_filters_rows():
+    """Typing in the search box hides rows that don't match."""
+    from tasks_tui.app import ProjectFilterRow
+    with (
+        patch("tasks_tui.app.list_tasks", return_value=[]),
+        patch("tasks_tui.app.list_completed_tasks", return_value=[]),
+        patch("tasks_tui.app.list_beads_issues", return_value=[]),
+        patch("tasks_tui.app.discover_beads_workspaces", return_value=_WORKSPACES),
+    ):
+        async with GTasksApp().run_test() as pilot:
+            screen = _push_filter_screen(pilot.app)
+            await pilot.pause()
+            # Type "alp" — only "alpha" should be visible
+            await pilot.press("a", "l", "p")
+            await pilot.pause()
+            rows = list(screen.query(ProjectFilterRow))
+            visible = [r for r in rows if r.display]
+            hidden = [r for r in rows if not r.display]
+            assert len(visible) == 1 and visible[0].project_name == "alpha"
+            assert len(hidden) == 1 and hidden[0].project_name == "beta"
+
+
+@pytest.mark.asyncio
+async def test_filter_screen_ctrl_a_n_keybindings():
+    """ctrl+a / ctrl+n keybindings toggle all rows without disturbing the search input."""
+    from tasks_tui.app import ProjectFilterRow
+    with (
+        patch("tasks_tui.app.list_tasks", return_value=[]),
+        patch("tasks_tui.app.list_completed_tasks", return_value=[]),
+        patch("tasks_tui.app.list_beads_issues", return_value=[]),
+        patch("tasks_tui.app.discover_beads_workspaces", return_value=_WORKSPACES),
+    ):
+        async with GTasksApp().run_test() as pilot:
+            screen = _push_filter_screen(pilot.app)
+            await pilot.pause()
+            # ctrl+a selects all
+            await pilot.press("ctrl+a")
+            await pilot.pause()
+            assert all(r.is_visible for r in screen.query(ProjectFilterRow))
+            # ctrl+n deselects all
+            await pilot.press("ctrl+n")
+            await pilot.pause()
+            assert not any(r.is_visible for r in screen.query(ProjectFilterRow))
+            # search input should be empty — keystrokes were not typed as text
+            from textual.widgets import Input as TInput
+            search_input = screen.query_one("#filter-search", TInput)
+            assert search_input.value == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- New `ProjectFilterScreen` modal: search input, per-project visible toggle, select-all (`a`) / deselect-all (`n`) shortcuts, close on `esc`
- Background worker discovers beads workspaces and populates rows
- Filter state persists to config and takes effect immediately on close (no separate Save step)

## Test plan
- [ ] Press `f` from main task view — verify filter panel opens
- [ ] Type in search box — verify rows filter in real-time by project name
- [ ] Toggle individual project visibility — verify task view updates on close
- [ ] Press `a` / `n` — verify select-all / deselect-all works
- [ ] Reopen filter panel — verify visibility state persisted
- [ ] Run `uv run pytest` — all 128 tests pass