### PR TITLE
feat: add custom sort to filter modal

### DIFF
--- a/docs/brainstorms/2026-05-12-custom-task-sort-brainstorm.md
+++ b/docs/brainstorms/2026-05-12-custom-task-sort-brainstorm.md
@@ -1,0 +1,48 @@
+# Custom Task Sort — Brainstorm
+
+**Date:** 2026-05-12
+**Status:** Ready for planning
+
+---
+
+## What We're Building
+
+A way for users to choose how the open task list is sorted at runtime. The sort is controlled through the existing filter modal (key `f`) and resets to the default on each session start.
+
+**Two sort options:**
+1. **Due date** (current default) — tasks with a due date first, sorted by urgency (`days_until_due`), no-due-date tasks last
+2. **Label** — group/sort by the `[label]` prefix alphabetically; within the same label, fall back to due date ordering
+
+---
+
+## Why This Approach
+
+- Extending the filter modal keeps UX consistent — users already go to `f` for display preferences
+- In-memory only matches how filters work today, avoiding a new config file dependency
+- Two sort fields (due date + label) covers the primary use cases without over-engineering
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Sort fields | Due date, Label | Most useful for the label-based workflow already in use |
+| UX entry point | Filter modal (`f`) | Consistent with existing filter UX; no new keybinding |
+| Persistence | In-memory, resets on restart | Simpler; consistent with existing filter behavior |
+| Default sort | Due date | Preserves current behavior for existing users |
+
+---
+
+## Implementation Notes
+
+- `task_list.py:46-48` — the sort key tuple to change based on selected sort
+- `config_screens.py` — filter modal to extend with a sort `Select` widget
+- `app.py` — pass `sort_by` state alongside `filter_days` / `filter_lists` to `render_task_list()`
+- Sort state lives on `GTasksApp` (same pattern as `filter_days`)
+
+---
+
+## Open Questions
+
+None.

--- a/docs/plans/2026-05-12-feat-custom-task-sort-plan.md
+++ b/docs/plans/2026-05-12-feat-custom-task-sort-plan.md
@@ -1,0 +1,132 @@
+---
+title: "feat: Add custom task sort to filter modal"
+type: feat
+status: active
+date: 2026-05-12
+---
+
+# feat: Add Custom Task Sort to Filter Modal
+
+Add a sort selector to the existing filter modal (`f`) so users can choose between **Due date** (default) and **Label** ordering for the open task list. State is in-memory only and resets to the default on restart.
+
+## Acceptance Criteria
+
+- [ ] Filter modal contains a "Sort by" `Select` widget with options: "Due date" and "Label"
+- [ ] Default selection is "Due date" — preserves existing sort behavior exactly
+- [ ] "Due date" sort: `(days_until_due is None, days_until_due or 0, label)` — tasks without due dates last, urgency ascending, label as tiebreaker
+- [ ] "Label" sort: tasks grouped alphabetically by `[label]` prefix; tasks with no label appear **last**; within a label, secondary sort by due date ascending
+- [ ] Modal opens with the currently active sort pre-selected (consistent with how `filter_days` works today)
+- [ ] Subtasks are not independently sorted — they continue to follow their parent (existing behavior)
+- [ ] Completed tasks section sort order is unchanged
+- [ ] Sort state resets to "Due date" on app restart (no persistence)
+
+## Implementation
+
+Three files change. No new files needed.
+
+### 1. `src/gtasks_tui/task_list.py`
+
+Add `sort_key: str = "due_date"` parameter to `render_task_list` (line 12).
+
+Replace the hardcoded sort at lines 46–48:
+
+```python
+# task_list.py:46
+if sort_key == "label":
+    top_level.sort(key=lambda t: (
+        not t.label,              # unlabeled tasks last
+        t.label or "",            # alphabetical among labeled
+        t.days_until_due is None,
+        t.days_until_due or 0,
+    ))
+else:  # "due_date" (default)
+    top_level.sort(
+        key=lambda t: (t.days_until_due is None, t.days_until_due or 0, t.label)
+    )
+```
+
+### 2. `src/gtasks_tui/screens/config_screens.py`
+
+Add options constant near `_DAYS_OPTIONS` (line ~11):
+
+```python
+# config_screens.py
+_SORT_OPTIONS: list[tuple[str, str]] = [
+    ("Due date", "due_date"),
+    ("Label", "label"),
+]
+```
+
+Extend `FilterScreen.__init__` with `sort_key: str = "due_date"`, store as `self._sort_key`.
+
+Add a "Sort by" `Select` widget to `compose()` alongside the existing `"filter-days"` Select:
+
+```python
+# config_screens.py — inside compose()
+yield Label("Sort by")
+yield Select(
+    [(label, value) for label, value in _SORT_OPTIONS],
+    value=self._sort_key,
+    id="sort-key",
+)
+```
+
+Extend `action_close` to read and include the sort value in the dismiss dict:
+
+```python
+# config_screens.py — action_close
+sort_key = self.query_one("#sort-key", Select).value or "due_date"
+self.dismiss({"days": days, "lists": selected, "sort_key": sort_key})
+```
+
+### 3. `src/gtasks_tui/app.py`
+
+Add state field in `__init__` (after `self._filter_lists`, line ~57):
+
+```python
+# app.py — __init__
+self._sort_key: str = "due_date"
+```
+
+In `action_filter`, pass `sort_key=self._sort_key` to `FilterScreen` and read it back in `on_result`:
+
+```python
+# app.py — action_filter
+def on_result(result: dict | None) -> None:
+    if result is not None:
+        self._filter_days = result["days"]
+        self._filter_lists = result.get("lists")
+        self._sort_key = result.get("sort_key", "due_date")  # add this line
+        self._apply_loaded_tasks(self._tasks, self._completed_tasks)
+
+self.push_screen(
+    FilterScreen(
+        filter_days=self._filter_days,
+        available_lists=self._available_lists,
+        selected_lists=self._filter_lists,
+        sort_key=self._sort_key,          # add this argument
+    ),
+    on_result,
+)
+```
+
+Forward `sort_key` in all `render_task_list` calls (lines ~104 and inside `_apply_loaded_tasks`):
+
+```python
+# app.py — render_task_list call sites
+render_task_list(
+    self.query_one("#task-list", ListView),
+    self._tasks,
+    self._completed_tasks,
+    filter_days=self._filter_days,
+    filter_lists=self._filter_lists,
+    sort_key=self._sort_key,    # add this argument
+)
+```
+
+## References
+
+- Current sort logic: `src/gtasks_tui/task_list.py:46-48`
+- Filter modal: `src/gtasks_tui/screens/config_screens.py:20-87`
+- App state + filter wiring: `src/gtasks_tui/app.py:52-59, 217-231`
+- Brainstorm: `docs/brainstorms/2026-05-12-custom-task-sort-brainstorm.md`

--- a/docs/plans/2026-05-12-feat-custom-task-sort-plan.md
+++ b/docs/plans/2026-05-12-feat-custom-task-sort-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "feat: Add custom task sort to filter modal"
 type: feat
-status: active
+status: completed
 date: 2026-05-12
 ---
 

--- a/src/gtasks_tui/app.py
+++ b/src/gtasks_tui/app.py
@@ -55,6 +55,7 @@ class GTasksApp(App):
         self._completed_tasks: list[Task] = []
         self._filter_days: int | None = 7
         self._filter_lists: set[str] | None = None
+        self._sort_key: str = "due_date"
         self._available_lists: list[str] = []
         self._load_generation: int = 0
 
@@ -107,6 +108,7 @@ class GTasksApp(App):
             self._completed_tasks,
             filter_days=self._filter_days,
             filter_lists=self._filter_lists,
+            sort_key=self._sort_key,
         )
 
     # ── Selection helpers ─────────────────────────────────────────────────────
@@ -219,6 +221,7 @@ class GTasksApp(App):
             if result is not None:
                 self._filter_days = result["days"]
                 self._filter_lists = result.get("lists")
+                self._sort_key = result.get("sort_key", "due_date")
                 self._apply_loaded_tasks(self._tasks, self._completed_tasks)
 
         self.push_screen(
@@ -226,6 +229,7 @@ class GTasksApp(App):
                 filter_days=self._filter_days,
                 available_lists=self._available_lists,
                 selected_lists=self._filter_lists,
+                sort_key=self._sort_key,
             ),
             on_result,
         )

--- a/src/gtasks_tui/app.py
+++ b/src/gtasks_tui/app.py
@@ -53,7 +53,7 @@ class GTasksApp(App):
         super().__init__()
         self._tasks: list[Task] = []
         self._completed_tasks: list[Task] = []
-        self._filter_days: int | None = None
+        self._filter_days: int | None = 7
         self._filter_lists: set[str] | None = None
         self._available_lists: list[str] = []
         self._load_generation: int = 0

--- a/src/gtasks_tui/screens/config_screens.py
+++ b/src/gtasks_tui/screens/config_screens.py
@@ -16,6 +16,11 @@ _DAYS_OPTIONS: list[tuple[str, int | None]] = [
     ("Last 90 days", 90),
 ]
 
+_SORT_OPTIONS: list[tuple[str, str]] = [
+    ("Due date", "due_date"),
+    ("Label", "label"),
+]
+
 
 class FilterScreen(ModalScreen):
     """Filter by completed-task recency and/or task list."""
@@ -30,6 +35,7 @@ class FilterScreen(ModalScreen):
         filter_days: int | None = None,
         available_lists: list[str] | None = None,
         selected_lists: set[str] | None = None,
+        sort_key: str = "due_date",
     ) -> None:
         super().__init__()
         self._filter_days = filter_days
@@ -38,6 +44,7 @@ class FilterScreen(ModalScreen):
         self._selected_lists = (
             selected_lists if selected_lists is not None else set(self._available_lists)
         )
+        self._sort_key = sort_key
 
     def compose(self) -> ComposeResult:
         with Vertical(id="filter-dialog"):
@@ -47,6 +54,12 @@ class FilterScreen(ModalScreen):
                 value=self._filter_days,
                 id="filter-days",
                 prompt="Show completed",
+            )
+            yield Label("Sort by", id="filter-sort-label")
+            yield Select(
+                [(label, val) for label, val in _SORT_OPTIONS],
+                value=self._sort_key,
+                id="sort-key",
             )
             if self._available_lists:
                 yield Label("Lists", id="filter-lists-label")
@@ -84,4 +97,9 @@ class FilterScreen(ModalScreen):
                 else selected_values
             )
 
-        self.dismiss({"days": days, "lists": selected})
+        sort_select = self.query_one("#sort-key", Select)
+        sort_key = (
+            sort_select.value if sort_select.value is not Select.BLANK else "due_date"
+        )
+
+        self.dismiss({"days": days, "lists": selected, "sort_key": sort_key})

--- a/src/gtasks_tui/task_list.py
+++ b/src/gtasks_tui/task_list.py
@@ -15,6 +15,7 @@ def render_task_list(
     completed_tasks: list[Task],
     filter_days: int | None = None,
     filter_lists: set[str] | None = None,
+    sort_key: str = "due_date",
 ) -> None:
     """Clear and repopulate *lv* with tasks and subtasks."""
     lv.clear()
@@ -43,9 +44,19 @@ def render_task_list(
             subtasks_by_parent.setdefault(t.parent_id, []).append(t)
 
     top_level = [t for t in tasks if not t.parent_id]
-    top_level.sort(
-        key=lambda t: (t.days_until_due is None, t.days_until_due or 0, t.label)
-    )
+    if sort_key == "label":
+        top_level.sort(
+            key=lambda t: (
+                not t.label,
+                t.label or "",
+                t.days_until_due is None,
+                t.days_until_due or 0,
+            )
+        )
+    else:
+        top_level.sort(
+            key=lambda t: (t.days_until_due is None, t.days_until_due or 0, t.label)
+        )
 
     lv.append(SectionHeader("Open", variant="open"))
     if top_level:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def freezegun_today():
     with (
         patch("gtasks_tui.tasks_api.datetime") as mock_dt,
         patch("gtasks_tui.date_utils.datetime") as mock_du_dt,
+        patch("gtasks_tui.task_list.datetime") as mock_tl_dt,
     ):
         mock_dt.fromisoformat.side_effect = lambda s: __import__(
             "datetime"
@@ -33,4 +34,5 @@ def freezegun_today():
         mock_du_dt.fromisoformat.side_effect = lambda s: __import__(
             "datetime"
         ).datetime.fromisoformat(s)
+        mock_tl_dt.now.return_value.date.return_value = fixed_date
         yield

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -64,7 +64,7 @@ async def test_renders_open_tasks():
 
 
 @pytest.mark.asyncio
-async def test_renders_completed_tasks():
+async def test_renders_completed_tasks(freezegun_today):
     with (
         patch("gtasks_tui.app.list_tasks", return_value=[]),
         patch("gtasks_tui.app.list_completed_tasks", return_value=COMPLETED_TASKS),
@@ -89,7 +89,7 @@ async def test_renders_open_section_header():
 
 
 @pytest.mark.asyncio
-async def test_renders_completed_section_header():
+async def test_renders_completed_section_header(freezegun_today):
     with (
         patch("gtasks_tui.app.list_tasks", return_value=[]),
         patch("gtasks_tui.app.list_completed_tasks", return_value=COMPLETED_TASKS),
@@ -178,7 +178,7 @@ async def test_space_completes_open_task():
 
 
 @pytest.mark.asyncio
-async def test_space_uncompletes_completed_task():
+async def test_space_uncompletes_completed_task(freezegun_today):
     with (
         patch("gtasks_tui.app.list_tasks", return_value=[]),
         patch("gtasks_tui.app.list_completed_tasks", return_value=COMPLETED_TASKS),
@@ -234,7 +234,7 @@ async def test_delete_open_task():
 
 
 @pytest.mark.asyncio
-async def test_delete_completed_task():
+async def test_delete_completed_task(freezegun_today):
     with (
         patch("gtasks_tui.app.list_tasks", return_value=[]),
         patch("gtasks_tui.app.list_completed_tasks", return_value=COMPLETED_TASKS),

--- a/tests/test_task_list.py
+++ b/tests/test_task_list.py
@@ -1,0 +1,99 @@
+"""Tests for render_task_list sort behavior."""
+
+from unittest.mock import patch
+
+import pytest
+
+from gtasks_tui.app import GTasksApp
+from gtasks_tui.tasks_api import Task
+
+SORT_TASKS = [
+    Task(
+        id="1",
+        title="[Work] Report",
+        status="needsAction",
+        due="2026-03-15T00:00:00.000Z",
+    ),
+    Task(
+        id="2",
+        title="[Home] Groceries",
+        status="needsAction",
+        due="2026-03-13T00:00:00.000Z",
+    ),
+    Task(
+        id="3",
+        title="Unlabeled urgent",
+        status="needsAction",
+        due="2026-03-12T00:00:00.000Z",
+    ),
+    Task(id="4", title="[Home] Clean", status="needsAction"),
+]
+
+
+@pytest.mark.asyncio
+async def test_default_sort_due_date_order(freezegun_today):
+    """Default (due date) sort: most urgent first, no-due-date last."""
+    tasks = [
+        Task(id="1", title="No due date", status="needsAction"),
+        Task(
+            id="2",
+            title="Due in 3 days",
+            status="needsAction",
+            due="2026-03-15T00:00:00.000Z",
+        ),
+        Task(
+            id="3",
+            title="Due today",
+            status="needsAction",
+            due="2026-03-12T00:00:00.000Z",
+        ),
+    ]
+    with (
+        patch("gtasks_tui.app.list_tasks", return_value=tasks),
+        patch("gtasks_tui.app.list_completed_tasks", return_value=[]),
+    ):
+        async with GTasksApp().run_test() as pilot:
+            await pilot.pause()
+            items = list(pilot.app.query("TaskItem"))
+            titles = [i.gtask.title for i in items]
+            assert titles.index("Due today") < titles.index("Due in 3 days")
+            assert titles.index("Due in 3 days") < titles.index("No due date")
+
+
+@pytest.mark.asyncio
+async def test_label_sort_alphabetical_and_unlabeled_last(freezegun_today):
+    """Label sort: alphabetical by label, unlabeled tasks last."""
+    with (
+        patch("gtasks_tui.app.list_tasks", return_value=SORT_TASKS),
+        patch("gtasks_tui.app.list_completed_tasks", return_value=[]),
+    ):
+        async with GTasksApp().run_test() as pilot:
+            await pilot.pause()
+            pilot.app._sort_key = "label"
+            pilot.app._apply_loaded_tasks(SORT_TASKS, [])
+            await pilot.pause()
+            items = list(pilot.app.query("TaskItem"))
+            titles = [i.gtask.title for i in items]
+            # Home tasks come before Work (alphabetical)
+            assert titles.index("[Home] Groceries") < titles.index("[Work] Report")
+            assert titles.index("[Home] Clean") < titles.index("[Work] Report")
+            # Unlabeled comes last
+            assert titles.index("Unlabeled urgent") > titles.index("[Work] Report")
+
+
+@pytest.mark.asyncio
+async def test_label_sort_secondary_due_date_within_label(freezegun_today):
+    """Label sort: within the same label, due date is the secondary sort."""
+    with (
+        patch("gtasks_tui.app.list_tasks", return_value=SORT_TASKS),
+        patch("gtasks_tui.app.list_completed_tasks", return_value=[]),
+    ):
+        async with GTasksApp().run_test() as pilot:
+            await pilot.pause()
+            pilot.app._sort_key = "label"
+            pilot.app._apply_loaded_tasks(SORT_TASKS, [])
+            await pilot.pause()
+            items = list(pilot.app.query("TaskItem"))
+            titles = [i.gtask.title for i in items]
+            # Within [Home]: Groceries (due Mar 13) before Clean (no due)
+            assert titles.index("[Home] Groceries") < titles.index("[Home] Clean")


### PR DESCRIPTION
## Summary

- Adds a \"Sort by\" selector to the existing filter modal (`f`) with two options: **Due date** (default) and **Label**
- **Due date** preserves the existing sort: urgent tasks first, no-due-date tasks last
- **Label** groups tasks alphabetically by `[label]` prefix; tasks without a label appear last; within the same label, secondary sort by due date
- Sort state is in-memory only — resets to \"Due date\" on restart, consistent with how filters work

## Testing

- Added `tests/test_task_list.py` with 3 tests covering: due date ordering, label sort alphabetical grouping, and within-label secondary due date sort
- Fixed 4 pre-existing test failures: `filter_days=7` default (set in d6d939f) was filtering out `COMPLETED_TASKS` fixture tasks when run with real time; fixed by extending `freezegun_today` in `conftest.py` to also patch `gtasks_tui.task_list.datetime`
- All 38 tests pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a pure in-memory, client-side sort with no network calls, persistence, or external side effects.